### PR TITLE
Prediction output

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ atoml is a command line tool that can be used with the following options.
                         if this flag is used
 -n,--instances <arg>    number of instances generated for each test set
                         (default: 100)
+-t,--timeout <arg>      timeout parameter for the created tests in seconds
+                        (default: 21600)
 -nomorph                no metamorphic tests are generated if this flag
                         is used
 -nosmoke                no smoke tests are generated if this flag is used

--- a/src/main/java/atoml/CmdParameters.java
+++ b/src/main/java/atoml/CmdParameters.java
@@ -87,6 +87,12 @@ public class CmdParameters {
 		numFeatures.setRequired(false);
 		options.addOption(numFeatures);
 		defaults.put("features", "10");
+
+		Option timeout = new Option("t", "timeout", true,
+				"timeout parameter for the created tests in seconds (default: 21600)");
+		timeout.setRequired(false);
+		options.addOption(timeout);
+		defaults.put("timeout", "21600");
 		
 		Option mysql = new Option("mysql", false,
 				"the results are stored in a local MySQL database if this flag is used");

--- a/src/main/java/atoml/CmdParameters.java
+++ b/src/main/java/atoml/CmdParameters.java
@@ -99,9 +99,14 @@ public class CmdParameters {
 		options.addOption(nosmoke);
 		
 		Option nomorph = new Option("nomorph", false,
-				"no metamorphic testa are generated if this flag is used");
+				"no metamorphic tests are generated if this flag is used");
 		nomorph.setRequired(false);
 		options.addOption(nomorph);
+
+		Option savePredictions = new Option("predictions", false,
+				"predictions of smoke tests are saved in csv files if this flag is used");
+		savePredictions.setRequired(false);
+		options.addOption(savePredictions);
 	}
 
 	/**

--- a/src/main/java/atoml/Runner.java
+++ b/src/main/java/atoml/Runner.java
@@ -34,8 +34,12 @@ public class Runner {
 	    final boolean useMysql = cmdParameters.hasOption("mysql");
 	    final boolean generateSmokeTests = !cmdParameters.hasOption("nosmoke");
 	    final boolean generateMorphTests = !cmdParameters.hasOption("nomorph");
-		System.setProperty("atoml.savepredictions", String.valueOf(cmdParameters.hasOption("predictions")));
-	    
+	    System.setProperty("atoml.savepredictions", String.valueOf(cmdParameters.hasOption("predictions")));
+
+		System.setProperty("atoml.weka.timeout", String.valueOf(1000 * cmdParameters.getIntegerValue("timeout")));
+		System.setProperty("atoml.sklearn.timeout", String.valueOf(1000 * cmdParameters.getIntegerValue("timeout")));
+		System.setProperty("atoml.spark.timeout", String.valueOf(1000 * cmdParameters.getIntegerValue("timeout")));
+
 		List<Algorithm> algorithms = YamlClassifierGenerator.parseFile(yamlFileStr);
 		TestsuiteGenerator testsuiteGenerator = new TestsuiteGenerator(numFeatures, numInstances);
 		System.setProperty("atoml.weka.datapath", "generated-tests/weka/src/test/resources/");

--- a/src/main/java/atoml/Runner.java
+++ b/src/main/java/atoml/Runner.java
@@ -34,7 +34,7 @@ public class Runner {
 	    final boolean useMysql = cmdParameters.hasOption("mysql");
 	    final boolean generateSmokeTests = !cmdParameters.hasOption("nosmoke");
 	    final boolean generateMorphTests = !cmdParameters.hasOption("nomorph");
-	    final boolean savePredictions = cmdParameters.hasOption("predictions");
+		System.setProperty("atoml.savepredictions", String.valueOf(cmdParameters.hasOption("predictions")));
 	    
 		List<Algorithm> algorithms = YamlClassifierGenerator.parseFile(yamlFileStr);
 		TestsuiteGenerator testsuiteGenerator = new TestsuiteGenerator(numFeatures, numInstances);
@@ -44,6 +44,6 @@ public class Runner {
 		System.setProperty("atoml.sklearn.testcasepath", "generated-tests/sklearn/");
 		System.setProperty("atoml.spark.datapath", "generated-tests/spark/src/test/resources/");
 		System.setProperty("atoml.spark.testcasepath", "generated-tests/spark/src/test/java/");
-		testsuiteGenerator.generateTests(algorithms, iterations, useMysql, generateSmokeTests, generateMorphTests, savePredictions);
+		testsuiteGenerator.generateTests(algorithms, iterations, useMysql, generateSmokeTests, generateMorphTests);
 	}
 }

--- a/src/main/java/atoml/Runner.java
+++ b/src/main/java/atoml/Runner.java
@@ -34,6 +34,7 @@ public class Runner {
 	    final boolean useMysql = cmdParameters.hasOption("mysql");
 	    final boolean generateSmokeTests = !cmdParameters.hasOption("nosmoke");
 	    final boolean generateMorphTests = !cmdParameters.hasOption("nomorph");
+	    final boolean savePredictions = cmdParameters.hasOption("predictions");
 	    
 		List<Algorithm> algorithms = YamlClassifierGenerator.parseFile(yamlFileStr);
 		TestsuiteGenerator testsuiteGenerator = new TestsuiteGenerator(numFeatures, numInstances);
@@ -43,6 +44,6 @@ public class Runner {
 		System.setProperty("atoml.sklearn.testcasepath", "generated-tests/sklearn/");
 		System.setProperty("atoml.spark.datapath", "generated-tests/spark/src/test/resources/");
 		System.setProperty("atoml.spark.testcasepath", "generated-tests/spark/src/test/java/");
-		testsuiteGenerator.generateTests(algorithms, iterations, useMysql, generateSmokeTests, generateMorphTests);
+		testsuiteGenerator.generateTests(algorithms, iterations, useMysql, generateSmokeTests, generateMorphTests, savePredictions);
 	}
 }

--- a/src/main/java/atoml/testgen/TestcaseGenerator.java
+++ b/src/main/java/atoml/testgen/TestcaseGenerator.java
@@ -161,6 +161,7 @@ public class TestcaseGenerator {
 
 		Map<String, String> replacementMap = templateEngine.getSmoketestReplacements(smokeTest);
 		replacementMap.put("<<<NAME>>>", smokeTest.getName());
+		replacementMap.put("<<<TIMEOUT>>>", System.getProperty("atoml."+this.algorithmUnderTest.getFramework()+".timeout"));
 		replacementMap.put("<<<ITERATIONS>>>", Integer.toString(iterations));
 		replacementMap.put("<<<IDENTIFIER>>>", this.algorithmUnderTest.getName());
 		for( String key : replacementMap.keySet()) {
@@ -183,6 +184,7 @@ public class TestcaseGenerator {
 		
 		Map<String,String> replacementMap = templateEngine.getMorphtestReplacements(metamorphicTest);
 		replacementMap.put("<<<NAME>>>", metamorphicTest.getName());
+		replacementMap.put("<<<TIMEOUT>>>", System.getProperty("atoml."+this.algorithmUnderTest.getFramework()+".timeout"));
 		replacementMap.put("<<<DATASET>>>", morphtestDataDescription.getName());
 		replacementMap.put("<<<ITERATIONS>>>", Integer.toString(iterations));
 		for( String key : replacementMap.keySet()) {

--- a/src/main/java/atoml/testgen/TestcaseGenerator.java
+++ b/src/main/java/atoml/testgen/TestcaseGenerator.java
@@ -33,8 +33,6 @@ public class TestcaseGenerator {
 	
 	private final boolean generateMorphTests;
 
-	private final boolean savePredictions;
-	
 	private final TemplateEngine templateEngine;
 	
 	/**
@@ -43,14 +41,13 @@ public class TestcaseGenerator {
 	 * @param morphtestDataDescriptions descriptions of the data sets used by morph tests
 	 * @param iterations number of iterations for the test (must match with generated data)
 	 */
-	public TestcaseGenerator(Algorithm algorithmUnderTest, List<DataDescription> morphtestDataDescriptions, int iterations, boolean useMysql, boolean generateSmokeTests, boolean generateMorphTests, boolean savePredictions) {
+	public TestcaseGenerator(Algorithm algorithmUnderTest, List<DataDescription> morphtestDataDescriptions, int iterations, boolean useMysql, boolean generateSmokeTests, boolean generateMorphTests) {
 		this.algorithmUnderTest = algorithmUnderTest;
 		this.morphtestDataDescriptions = morphtestDataDescriptions;
 		this.iterations = iterations; 
 		this.useMysql = useMysql;
 		this.generateSmokeTests = generateSmokeTests;
 		this.generateMorphTests = generateMorphTests;
-		this.savePredictions = savePredictions;
 		switch(algorithmUnderTest.getFramework()) {
 		case "weka":
 			templateEngine = new WekaTemplate(algorithmUnderTest);
@@ -152,7 +149,7 @@ public class TestcaseGenerator {
 		}
 
 		String smokeResourceEnding = new String();
-		if( this.savePredictions && this.algorithmUnderTest.getAlgorithmType().equals("classification") ) {
+		if( Boolean.getBoolean("atoml.savepredictions") && this.algorithmUnderTest.getAlgorithmType().equals("classification") ) {
 			smokeResourceEnding = "-smoketest-csv.template";
 		} else {
 			smokeResourceEnding = "-smoketest.template";

--- a/src/main/java/atoml/testgen/TestcaseGenerator.java
+++ b/src/main/java/atoml/testgen/TestcaseGenerator.java
@@ -157,8 +157,6 @@ public class TestcaseGenerator {
 		@SuppressWarnings("resource")
 		String methodBody = new Scanner(this.getClass().getResourceAsStream(getResourcePrefix()+smokeResourceEnding), "UTF-8").useDelimiter("\\A").next();
 
-
-
 		Map<String, String> replacementMap = templateEngine.getSmoketestReplacements(smokeTest);
 		replacementMap.put("<<<NAME>>>", smokeTest.getName());
 		replacementMap.put("<<<TIMEOUT>>>", System.getProperty("atoml."+this.algorithmUnderTest.getFramework()+".timeout"));

--- a/src/main/java/atoml/testgen/TestsuiteGenerator.java
+++ b/src/main/java/atoml/testgen/TestsuiteGenerator.java
@@ -45,7 +45,7 @@ public class TestsuiteGenerator {
 		this.numInstances = numInstances;
 	}
 	
-	public void generateTests(List<Algorithm> algorithmsUnderTest, int iterations, boolean useMysql, boolean generateSmokeTests, boolean generateMorphTests, boolean savePredictions) {
+	public void generateTests(List<Algorithm> algorithmsUnderTest, int iterations, boolean useMysql, boolean generateSmokeTests, boolean generateMorphTests) {
 		// get frameworks from algorithms
 		Set<String> frameworks = new LinkedHashSet<>();
 		for(Algorithm algorithm : algorithmsUnderTest) {
@@ -69,7 +69,7 @@ public class TestsuiteGenerator {
 		
 		for(Algorithm algorithmUnderTest : algorithmsUnderTest ) {
 			LOGGER.info("creating tests for " + algorithmUnderTest.getName() + "...");
-			TestcaseGenerator testcaseGenerator = new TestcaseGenerator(algorithmUnderTest, morphtestDataDescriptions, iterations, useMysql, generateSmokeTests, generateMorphTests, savePredictions);
+			TestcaseGenerator testcaseGenerator = new TestcaseGenerator(algorithmUnderTest, morphtestDataDescriptions, iterations, useMysql, generateSmokeTests, generateMorphTests);
 			String testclassCode = testcaseGenerator.generateSource();
 			
 			Path path = Paths.get(testcasePaths.get(algorithmUnderTest.getFramework())).resolve(testcaseGenerator.getFilePath());

--- a/src/main/java/atoml/testgen/TestsuiteGenerator.java
+++ b/src/main/java/atoml/testgen/TestsuiteGenerator.java
@@ -45,7 +45,7 @@ public class TestsuiteGenerator {
 		this.numInstances = numInstances;
 	}
 	
-	public void generateTests(List<Algorithm> algorithmsUnderTest, int iterations, boolean useMysql, boolean generateSmokeTests, boolean generateMorphTests) {
+	public void generateTests(List<Algorithm> algorithmsUnderTest, int iterations, boolean useMysql, boolean generateSmokeTests, boolean generateMorphTests, boolean savePredictions) {
 		// get frameworks from algorithms
 		Set<String> frameworks = new LinkedHashSet<>();
 		for(Algorithm algorithm : algorithmsUnderTest) {
@@ -69,7 +69,7 @@ public class TestsuiteGenerator {
 		
 		for(Algorithm algorithmUnderTest : algorithmsUnderTest ) {
 			LOGGER.info("creating tests for " + algorithmUnderTest.getName() + "...");
-			TestcaseGenerator testcaseGenerator = new TestcaseGenerator(algorithmUnderTest, morphtestDataDescriptions, iterations, useMysql, generateSmokeTests, generateMorphTests);
+			TestcaseGenerator testcaseGenerator = new TestcaseGenerator(algorithmUnderTest, morphtestDataDescriptions, iterations, useMysql, generateSmokeTests, generateMorphTests, savePredictions);
 			String testclassCode = testcaseGenerator.generateSource();
 			
 			Path path = Paths.get(testcasePaths.get(algorithmUnderTest.getFramework())).resolve(testcaseGenerator.getFilePath());

--- a/src/main/resources/sklearn-classification-class.template
+++ b/src/main/resources/sklearn-classification-class.template
@@ -8,8 +8,10 @@ import inspect
 import math
 import traceback
 import warnings
+import os
 
 from parameterized import parameterized
+from pathlib import Path
 from scipy.io.arff import loadarff
 from scipy.stats import chisquare, ks_2samp
 from sklearn.preprocessing import LabelEncoder

--- a/src/main/resources/sklearn-classification-morphtest.template
+++ b/src/main/resources/sklearn-classification-morphtest.template
@@ -1,5 +1,5 @@
     @parameterized.expand(params)
-    @timeout(21600)
+    @timeout(<<<TIMEOUT>>>)
     def test_<<<NAME>>>_<<<DATASET>>>(self, name, kwargs):
         for iter in range(1,<<<ITERATIONS>>>+1):
             no_exception = True

--- a/src/main/resources/sklearn-classification-smoketest-csv.template
+++ b/src/main/resources/sklearn-classification-smoketest-csv.template
@@ -1,0 +1,38 @@
+    @parameterized.expand(params)
+    @timeout(21600)
+    def test_<<<NAME>>>(self, name, kwargs):
+        for iter in range(1,<<<ITERATIONS>>>+1):
+            <<<MYSQLEVALSMOKE_START>>><<<MYSQLINDENT>>>data, meta = loadarff('smokedata/<<<NAME>>>_%i_training.arff' % iter)
+            <<<MYSQLINDENT>>>testdata, testmeta = loadarff('smokedata/<<<NAME>>>_%i_test.arff' % iter)
+            <<<MYSQLINDENT>>>lb_make = LabelEncoder()
+            <<<MYSQLINDENT>>>data_df = pd.DataFrame(data)
+            <<<MYSQLINDENT>>>data_df["classAtt"] = lb_make.fit_transform(data_df["classAtt"])
+            <<<MYSQLINDENT>>>data_df = pd.get_dummies(data_df)
+            <<<MYSQLINDENT>>>
+            <<<MYSQLINDENT>>>testdata_df = pd.DataFrame(data)
+            <<<MYSQLINDENT>>>testdata_df["classAtt"] = lb_make.fit_transform(testdata_df["classAtt"])
+            <<<MYSQLINDENT>>>testdata_df = pd.get_dummies(testdata_df, sparse=True)
+            <<<MYSQLINDENT>>>
+            <<<MYSQLINDENT>>>classIndex = -1
+            <<<MYSQLINDENT>>>for i, s in enumerate(data_df.columns):
+            <<<MYSQLINDENT>>>    if 'classAtt' in s:
+            <<<MYSQLINDENT>>>        classIndex = i
+            <<<MYSQLINDENT>>>
+            <<<MYSQLINDENT>>>classifier = <<<CLASSIFIER>>>
+            <<<MYSQLINDENT>>>np.random.seed(42)
+            <<<MYSQLINDENT>>>classifier.fit(np.delete(data_df.values, classIndex, axis=1),data_df.values[:,classIndex])
+            <<<MYSQLINDENT>>>predictedLabel = classifier.predict(np.delete(testdata_df.values, classIndex, axis=1))<<<MYSQLEVALSMOKE_END>>>
+            try:
+                predProb = np.array(classifier.predict_proba(np.delete(testdata_df.values, classIndex, axis=1)))
+                main_dir = Path(__file__).resolve().parents[2]
+                predictionFile = os.path.join(main_dir, "predictions", "pred_" + "<<<IDENTIFIER>>>" + "_<<<NAME>>>_" + str(iter) + ".csv")
+                pred_df = pd.DataFrame()
+                pred_df['actual'] = testdata_df.classAtt
+                pred_df['prediction'] = predictedLabel
+                pred_df['prob_0'] = predProb[:,0]
+                pred_df['prob_1'] = predProb[:,1]
+                pred_df.to_csv(predictionFile, header=True, index=False)
+                print("Predictions saved at: " + predictionFile)
+            except Exception as e:
+                print("Saving the predictions of <<<NAME>>> for <<<IDENTIFIER>>> failed: ", e)
+

--- a/src/main/resources/sklearn-classification-smoketest-csv.template
+++ b/src/main/resources/sklearn-classification-smoketest-csv.template
@@ -1,5 +1,5 @@
     @parameterized.expand(params)
-    @timeout(21600)
+    @timeout(<<<TIMEOUT>>>)
     def test_<<<NAME>>>(self, name, kwargs):
         for iter in range(1,<<<ITERATIONS>>>+1):
             <<<MYSQLEVALSMOKE_START>>><<<MYSQLINDENT>>>data, meta = loadarff('smokedata/<<<NAME>>>_%i_training.arff' % iter)

--- a/src/main/resources/sklearn-classification-smoketest.template
+++ b/src/main/resources/sklearn-classification-smoketest.template
@@ -1,5 +1,5 @@
     @parameterized.expand(params)
-    @timeout(21600)
+    @timeout(<<<TIMEOUT>>>)
     def test_<<<NAME>>>(self, name, kwargs):
         for iter in range(1,<<<ITERATIONS>>>+1):
             <<<MYSQLEVALSMOKE_START>>><<<MYSQLINDENT>>>data, meta = loadarff('smokedata/<<<NAME>>>_%i_training.arff' % iter)

--- a/src/main/resources/sklearn-clustering-morphtest.template
+++ b/src/main/resources/sklearn-clustering-morphtest.template
@@ -1,5 +1,5 @@
     @parameterized.expand(params)
-    @timeout(21600)
+    @timeout(<<<TIMEOUT>>>)
     def test_<<<NAME>>>_<<<DATASET>>>(self, name, kwargs):
         for iter in range(1,<<<ITERATIONS>>>+1):
             no_exception = True

--- a/src/main/resources/sklearn-clustering-smoketest.template
+++ b/src/main/resources/sklearn-clustering-smoketest.template
@@ -1,5 +1,5 @@
     @parameterized.expand(params)
-    @timeout(21600)
+    @timeout(<<<TIMEOUT>>>)
     def test_<<<NAME>>>(self, name, kwargs):
         for iter in range(1,<<<ITERATIONS>>>+1):
             <<<MYSQLEVALSMOKE_START>>><<<MYSQLINDENT>>>data, meta = loadarff('smokedata/<<<NAME>>>_%i_training.arff' % iter)

--- a/src/main/resources/spark-classification-class.template
+++ b/src/main/resources/spark-classification-class.template
@@ -15,6 +15,8 @@ import org.junit.runners.Parameterized.Parameters;
 
 import javax.annotation.Generated;
 import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileWriter;
 import java.io.InputStreamReader;
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -32,6 +34,7 @@ import weka.core.Instances;
 import smile.stat.hypothesis.KSTest;
 import smile.stat.hypothesis.ChiSqTest;
 import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Encoders;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.RowFactory;
 import org.apache.spark.sql.SparkSession;
@@ -42,6 +45,7 @@ import org.apache.spark.ml.feature.OneHotEncoder;
 import org.apache.spark.ml.feature.OneHotEncoderModel;
 import org.apache.spark.ml.feature.VectorAssembler;
 import org.apache.spark.ml.linalg.DenseVector;
+import org.apache.spark.api.java.function.MapFunction;
 
 <<<MYSQLIMPORTS>>>
 

--- a/src/main/resources/spark-classification-morphtest.template
+++ b/src/main/resources/spark-classification-morphtest.template
@@ -1,4 +1,4 @@
-    @Test(timeout=600000)
+    @Test(timeout=<<<TIMEOUT>>>)
     public void test_<<<NAME>>>_<<<DATASET>>>() throws Exception {
         for(int iter=1; iter<=<<<ITERATIONS>>>; iter++) {
             boolean passed = true;

--- a/src/main/resources/spark-classification-smoketest-csv.template
+++ b/src/main/resources/spark-classification-smoketest-csv.template
@@ -1,0 +1,47 @@
+    @Test
+    public void test_<<<NAME>>>() throws Exception {
+        for(int iter=1; iter<=<<<ITERATIONS>>>; iter++) {
+        	<<<MYSQLEVALSMOKE_START>>>Dataset<Row> dataframe = arffToDataset("/smokedata/<<<NAME>>>_" + iter + "_training.arff");
+            Dataset<Row> testdata = arffToDataset("/smokedata/<<<NAME>>>_" + iter + "_test.arff");
+
+            <<<CLASSIFIER>>> classifier = new <<<CLASSIFIER>>>();
+            classifier.setLabelCol("classAtt");
+            try {
+            	Method setSeedMethod = classifier.getClass().getMethod("setSeed", long.class);
+            	setSeedMethod.invoke(classifier, 42);
+            } catch (NoSuchMethodException | SecurityException e) {
+            	// not randomized
+            }
+            setParameters(classifier, parameters);
+
+            ClassificationModel<?, ?> model = classifier.fit(dataframe);
+            Dataset<Row> pred = model.transform(testdata);<<<MYSQLEVALSMOKE_END>>>
+            // create a csv file
+            String filePath = "predictions/pred_<<<IDENTIFIER>>>_<<<NAME>>>_" + iter + ".csv";
+            try {
+                File outFile = new File(filePath);
+                outFile.createNewFile();
+            } catch (IOException e) {
+                System.out.println( "Creating the csv file failed." );
+                e.printStackTrace();
+            }
+            // write in csv
+            try {
+                FileWriter outWriter = new FileWriter(filePath);
+                // write header
+                outWriter.write("actual,prediction,prob_0,prob_1\\n");
+                // write predictions
+                Dataset<Row> predSelect = pred.select("classAtt", "prediction", "probability");
+                List<String> predString = predSelect.map((MapFunction<Row, String>) row -> row.mkString(","), Encoders.STRING()).collectAsList();
+                for (String s : predString) {
+                    outWriter.write(s.replace("[", "").replace("]", "") + '\\n');
+                };
+                outWriter.close();
+                System.out.println( "Predictions saved at: " + filePath );
+            } catch (IOException e) {
+                System.out.println( "Writing the predictions to csv file failed." );
+                e.printStackTrace();
+            }
+        }
+    }
+

--- a/src/main/resources/spark-classification-smoketest-csv.template
+++ b/src/main/resources/spark-classification-smoketest-csv.template
@@ -1,4 +1,4 @@
-    @Test
+    @Test(timeout=<<<TIMEOUT>>>)
     public void test_<<<NAME>>>() throws Exception {
         for(int iter=1; iter<=<<<ITERATIONS>>>; iter++) {
         	<<<MYSQLEVALSMOKE_START>>>Dataset<Row> dataframe = arffToDataset("/smokedata/<<<NAME>>>_" + iter + "_training.arff");

--- a/src/main/resources/spark-classification-smoketest.template
+++ b/src/main/resources/spark-classification-smoketest.template
@@ -1,4 +1,4 @@
-    @Test(timeout=600000)
+    @Test(timeout=<<<TIMEOUT>>>)
     public void test_<<<NAME>>>() throws Exception {
         for(int iter=1; iter<=<<<ITERATIONS>>>; iter++) {
         	<<<MYSQLEVALSMOKE_START>>>Dataset<Row> dataframe = arffToDataset("/smokedata/<<<NAME>>>_" + iter + "_training.arff");

--- a/src/main/resources/spark-clustering-morphtest.template
+++ b/src/main/resources/spark-clustering-morphtest.template
@@ -1,4 +1,4 @@
-    @Test(timeout=600000)
+    @Test(timeout=<<<TIMEOUT>>>)
     public void test_<<<NAME>>>_<<<DATASET>>>() throws Exception {
         for(int iter=1; iter<=<<<ITERATIONS>>>; iter++) {
             boolean passed = true;

--- a/src/main/resources/spark-clustering-smoketest.template
+++ b/src/main/resources/spark-clustering-smoketest.template
@@ -1,4 +1,4 @@
-    @Test(timeout=600000)
+    @Test(timeout=<<<TIMEOUT>>>)
     public void test_<<<NAME>>>() throws Exception {
         for(int iter=1; iter<=<<<ITERATIONS>>>; iter++) {
         	<<<MYSQLEVALSMOKE_START>>><<<MYSQLINDENT>>>Dataset<Row> dataframe = arffToDataset("/smokedata/<<<NAME>>>_" + iter + "_training.arff");

--- a/src/main/resources/weka-classification-class.template
+++ b/src/main/resources/weka-classification-class.template
@@ -14,16 +14,20 @@ import org.junit.runners.Parameterized.Parameters;
 
 import javax.annotation.Generated;
 import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileWriter;
 import java.io.InputStreamReader;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import smile.stat.hypothesis.KSTest;
 import smile.stat.hypothesis.ChiSqTest;
 import weka.classifiers.Classifier;
 import weka.classifiers.AbstractClassifier;
+import weka.classifiers.evaluation.Evaluation;
 import weka.core.Instances;
 import weka.core.Instance;
 

--- a/src/main/resources/weka-classification-morphtest.template
+++ b/src/main/resources/weka-classification-morphtest.template
@@ -1,4 +1,4 @@
-    @Test(timeout=600000)
+    @Test(timeout=<<<TIMEOUT>>>)
     public void test_<<<NAME>>>_<<<DATASET>>>() throws Exception {
         for(int iter=1; iter<=<<<ITERATIONS>>>; iter++) {
             boolean passed = true;

--- a/src/main/resources/weka-classification-smoketest-csv.template
+++ b/src/main/resources/weka-classification-smoketest-csv.template
@@ -1,0 +1,46 @@
+    @Test(timeout=21600000)
+    public void test_<<<NAME>>>() throws Exception {
+        for(int iter=1; iter<=<<<ITERATIONS>>>; iter++) {
+            <<<MYSQLEVALSMOKE_START>>>Instances data = loadData("/smokedata/<<<NAME>>>_" + iter + "_training.arff");
+            Instances testdata = loadData("/smokedata/<<<NAME>>>_" + iter + "_test.arff");
+            Classifier classifier = AbstractClassifier.forName("<<<PACKAGENAME>>>.<<<CLASSIFIER>>>", Arrays.copyOf(parameters, parameters.length));
+            classifier.buildClassifier(data);
+            for (Instance instance : testdata) {
+                classifier.classifyInstance(instance);
+                classifier.distributionForInstance(instance);
+            }<<<MYSQLEVALSMOKE_END>>>
+            // get predictions on full testdata
+            Evaluation eval = null;
+            try {
+                eval = new Evaluation(data);
+                eval.evaluateModel(classifier, testdata);
+            } catch (Exception ex) {
+            }
+            ArrayList pred = eval.predictions();
+            // create a csv file
+            String filePath = "predictions/pred_<<<IDENTIFIER>>>_<<<NAME>>>_" + iter + ".csv";
+            try {
+                File outFile = new File(filePath);
+                outFile.createNewFile();
+            } catch (IOException e) {
+                System.out.println( "Creating the csv file failed." );
+                e.printStackTrace();
+            }
+            // write in csv
+            try {
+                FileWriter outWriter = new FileWriter(filePath);
+                // write header
+                outWriter.write("type,actual,prediction,weigth,prob_0,prob_1\\n");
+                // write predictions
+                for (Object i : pred) {
+                    outWriter.write(i.toString().replace(" ", ",") + '\\n');
+                };
+                outWriter.close();
+                System.out.println( "Predictions saved at: " + filePath );
+            } catch (IOException e) {
+                System.out.println( "Writing the predictions to csv file failed." );
+                e.printStackTrace();
+            }
+        }
+    }
+

--- a/src/main/resources/weka-classification-smoketest-csv.template
+++ b/src/main/resources/weka-classification-smoketest-csv.template
@@ -1,4 +1,4 @@
-    @Test(timeout=21600000)
+    @Test(timeout=<<<TIMEOUT>>>)
     public void test_<<<NAME>>>() throws Exception {
         for(int iter=1; iter<=<<<ITERATIONS>>>; iter++) {
             <<<MYSQLEVALSMOKE_START>>>Instances data = loadData("/smokedata/<<<NAME>>>_" + iter + "_training.arff");

--- a/src/main/resources/weka-classification-smoketest.template
+++ b/src/main/resources/weka-classification-smoketest.template
@@ -1,4 +1,4 @@
-    @Test(timeout=21600000)
+    @Test(timeout=<<<TIMEOUT>>>)
     public void test_<<<NAME>>>() throws Exception {
         for(int iter=1; iter<=<<<ITERATIONS>>>; iter++) {
             <<<MYSQLEVALSMOKE_START>>>Instances data = loadData("/smokedata/<<<NAME>>>_" + iter + "_training.arff");

--- a/src/main/resources/weka-clustering-morphtest.template
+++ b/src/main/resources/weka-clustering-morphtest.template
@@ -1,4 +1,4 @@
-    @Test(timeout=600000)
+    @Test(timeout=<<<TIMEOUT>>>)
     public void test_<<<NAME>>>_<<<DATASET>>>() throws Exception {
         for(int iter=1; iter<=<<<ITERATIONS>>>; iter++) {
             boolean passed = true;

--- a/src/main/resources/weka-clustering-smoketest.template
+++ b/src/main/resources/weka-clustering-smoketest.template
@@ -1,4 +1,4 @@
-    @Test(timeout=21600000)
+    @Test(timeout=<<<TIMEOUT>>>)
     public void test_<<<NAME>>>() throws Exception {
         for(int iter=1; iter<=<<<ITERATIONS>>>; iter++) {
             <<<MYSQLEVALSMOKE_START>>><<<MYSQLINDENT>>>Instances data = loadData("/smokedata/<<<NAME>>>_" + iter + "_training.arff");

--- a/src/test/java/atoml/YamlTestgenerationTest.java
+++ b/src/test/java/atoml/YamlTestgenerationTest.java
@@ -25,6 +25,9 @@ public class YamlTestgenerationTest {
 	
 	@Test
 	public void test() throws Exception {
+		System.setProperty("atoml.weka.timeout", String.valueOf(1000000));
+		System.setProperty("atoml.sklearn.timeout", String.valueOf(1000000));
+		System.setProperty("atoml.spark.timeout", String.valueOf(1000000));
 		List<Algorithm> algorithms = YamlClassifierGenerator.parseFile("testdata/descriptions.yml");
 		int numFeatures = 10;
 		int numInstances = 100;

--- a/src/test/java/atoml/YamlTestgenerationTest.java
+++ b/src/test/java/atoml/YamlTestgenerationTest.java
@@ -39,7 +39,7 @@ public class YamlTestgenerationTest {
 		int iterations = 2;
 		for(Algorithm alg : algorithms) {
 			System.out.println(alg);
-			TestcaseGenerator testcaseGenerator = new TestcaseGenerator(alg, morphtestDataDescriptions, iterations, false, true, true);
+			TestcaseGenerator testcaseGenerator = new TestcaseGenerator(alg, morphtestDataDescriptions, iterations, false, true, true, false);
 			String source = testcaseGenerator.generateSource();
 			System.out.println(source);
 		}

--- a/src/test/java/atoml/YamlTestgenerationTest.java
+++ b/src/test/java/atoml/YamlTestgenerationTest.java
@@ -39,7 +39,7 @@ public class YamlTestgenerationTest {
 		int iterations = 2;
 		for(Algorithm alg : algorithms) {
 			System.out.println(alg);
-			TestcaseGenerator testcaseGenerator = new TestcaseGenerator(alg, morphtestDataDescriptions, iterations, false, true, true, false);
+			TestcaseGenerator testcaseGenerator = new TestcaseGenerator(alg, morphtestDataDescriptions, iterations, false, true, true);
 			String source = testcaseGenerator.generateSource();
 			System.out.println(source);
 		}


### PR DESCRIPTION
Adds two options to the command: "predictions" and "timeout"

The prediction saving smoketests are implemented by an additional template file: 'FW-classification-smoketest**-csv**.template'.

The timeout functionality uses internally separated system properties for the different frameworks (e.g. atoml.sklearn.timeout). The reason is that the timeout for testing in different frameworks can be implemented differently (mainly in seconds or ms). However, the current frameworks tests are all based on implementations with milliseconds (threading.thread.join(time) for sklearn and the JUnit Timeout for Spark and Java).