### PR TITLE
minor fixes

### DIFF
--- a/src/main/java/atoml/Runner.java
+++ b/src/main/java/atoml/Runner.java
@@ -37,7 +37,7 @@ public class Runner {
 	    System.setProperty("atoml.savepredictions", String.valueOf(cmdParameters.hasOption("predictions")));
 
 		System.setProperty("atoml.weka.timeout", String.valueOf(1000 * cmdParameters.getIntegerValue("timeout")));
-		System.setProperty("atoml.sklearn.timeout", String.valueOf(1000 * cmdParameters.getIntegerValue("timeout")));
+		System.setProperty("atoml.sklearn.timeout", String.valueOf(1 * cmdParameters.getIntegerValue("timeout")));
 		System.setProperty("atoml.spark.timeout", String.valueOf(1000 * cmdParameters.getIntegerValue("timeout")));
 		System.setProperty("atoml.caret.timeout", String.valueOf(1 * cmdParameters.getIntegerValue("timeout")));
 

--- a/src/main/java/atoml/testgen/TestcaseGenerator.java
+++ b/src/main/java/atoml/testgen/TestcaseGenerator.java
@@ -220,7 +220,7 @@ public class TestcaseGenerator {
 	}
 	
 	private String getResourcePrefix() {
-		return "/"+algorithmUnderTest.getFramework()+"-"+algorithmUnderTest.getAlgorithmType();
+		return "/"+algorithmUnderTest.getFramework().toLowerCase()+"-"+algorithmUnderTest.getAlgorithmType();
 	}
 	
 	private List<SmokeTest> getSmoketests(List<FeatureType> features) {

--- a/src/main/resources/caret-classification-smoketest-csv.template
+++ b/src/main/resources/caret-classification-smoketest-csv.template
@@ -29,9 +29,11 @@ withTimeout(timeout=<<<TIMEOUT>>>, onTimeout="error", expr={
                           prediction = pred_classes,
                           prob_0 = probabilities[,1],
                           prob_1 = probabilities[,2])
+            csv_file <- file.path(dirname(dirname(getwd())),"predictions",paste0("pred_<<<IDENTIFIER>>>_<<<NAME>>>_",iter,".csv"))
             write.csv(x = csv_df,
-                    file = file.path(dirname(dirname(getwd())),"predictions",paste0("pred_<<<IDENTIFIER>>>_<<<NAME>>>_",iter,".csv")),
+                    file = csv_file,
                     row.names = FALSE)
+            print(paste0("Predictions saved at: ", csv_file))
         }
     expect_true(TRUE)
     })

--- a/src/test/java/atoml/YamlTestgenerationTest.java
+++ b/src/test/java/atoml/YamlTestgenerationTest.java
@@ -26,7 +26,7 @@ public class YamlTestgenerationTest {
 	@Test
 	public void test() throws Exception {
 		System.setProperty("atoml.weka.timeout", String.valueOf(1000000));
-		System.setProperty("atoml.sklearn.timeout", String.valueOf(1000000));
+		System.setProperty("atoml.sklearn.timeout", String.valueOf(1000));
 		System.setProperty("atoml.spark.timeout", String.valueOf(1000000));
 		System.setProperty("atoml.caret.timeout", String.valueOf(1000));
 		List<Algorithm> algorithms = YamlClassifierGenerator.parseFile("testdata/descriptions.yml");


### PR DESCRIPTION
-change sklearn timeout (threading.join(timeout_time)) to seconds as default.
-put framework names to lower case for template scanning (the .template files are all lower case)
-add prediction save print for caret, similar to the other frameworks