### PR TITLE
extend test generation from arff: training data != test data

### DIFF
--- a/src/main/java/atoml/smoke/SmoketestFromArff.java
+++ b/src/main/java/atoml/smoke/SmoketestFromArff.java
@@ -7,14 +7,32 @@ import java.io.InputStreamReader;
 import atoml.classifiers.FeatureType;
 import weka.core.Instances;
 
+/**
+ * Features: derived from ARFF
+ * Class: derived from ARFF
+ *
+ * @author sherbold
+ */
 public class SmoketestFromArff extends AbstractSmokeTest {
 
 	private final String trainingResource;
 	private final String testResource;
 
+	/**
+	 * creates a new SmoketestFromArff, where training data == test data
+	 * @param name identifier name of the test
+	 * @param trainingResource resource path of the ARFF file with the data
+	 */
 	public SmoketestFromArff(String name, String trainingResource) {
 		this(name, trainingResource, trainingResource);
 	}
+
+	/**
+	 * creates a new SmoketestFromArff
+	 * @param name identifier name of the test
+	 * @param trainingResource resource path of the ARFF file with the training data
+	 * @param testResource resource path of the ARFF file with the test data
+	 */
 	public SmoketestFromArff(String name, String trainingResource, String testResource) {
 		super();
 		this.name = name;
@@ -27,61 +45,46 @@ public class SmoketestFromArff extends AbstractSmokeTest {
 			throw new RuntimeException("error test data ARFF resource for smoke test generation is null");
 		}
 	}
-	
+
+	/*
+	 * (non-Javadoc)
+	 * @see atoml.smoke.SmokeTest#generateData(int, int, long)
+	 */
 	@Override
 	public void generateData(int numFeatures, int numInstances, long seed) {
-		InputStreamReader trainingFile = null;
-		BufferedReader trainingReader = null;
+		data = readDataFromArff(trainingResource);
+		testdata = readDataFromArff(testResource);
+	}
+
+	private Instances readDataFromArff(String resource){
+		InputStreamReader dataFile = null;
+		BufferedReader reader = null;
+		Instances dataset;
 		try{
-			trainingFile = new InputStreamReader(this.getClass().getResourceAsStream(trainingResource));
-			trainingReader = new BufferedReader(trainingFile);
-			data = new Instances(trainingReader);
+			dataFile = new InputStreamReader(this.getClass().getResourceAsStream(resource));
+			reader = new BufferedReader(dataFile);
+			dataset = new Instances(reader);
 		}
 		catch (IOException e) {
-			throw new RuntimeException("error reading ARFF from resource: " + trainingResource, e);
+			throw new RuntimeException("error reading ARFF from resource: " + resource, e);
 		}
 		finally {
-			if (trainingReader != null) {
+			if (reader != null) {
 				try {
-					trainingReader.close();
+					reader.close();
 				} catch (IOException e) {
-					throw new RuntimeException("error closing BufferedReader for resource: " + trainingResource, e);
+					throw new RuntimeException("error closing BufferedReader for resource: " + resource, e);
 				}
 			}
-			if (trainingFile != null){
+			if (dataFile != null){
 				try {
-					trainingFile.close();
+					dataFile.close();
 				} catch (IOException e) {
-					throw new RuntimeException("error closing InputStreamReader for resource: " + trainingResource, e);
-				}
-			}
-		}
-		InputStreamReader testFile = null;
-		BufferedReader testReader = null;
-		try{
-			testFile = new InputStreamReader(this.getClass().getResourceAsStream(testResource));
-			testReader = new BufferedReader(testFile);
-			testdata = new Instances(testReader);
-		}
-		catch (IOException e) {
-			throw new RuntimeException("error reading ARFF from resource: " + testResource, e);
-		}
-		finally {
-			if (testReader != null) {
-				try {
-					testReader.close();
-				} catch (IOException e) {
-					throw new RuntimeException("error closing BufferedReader for resource: " + testResource, e);
-				}
-			}
-			if (testFile != null){
-				try {
-					testFile.close();
-				} catch (IOException e) {
-					throw new RuntimeException("error closing InputStreamReader for resource: " + testResource, e);
+					throw new RuntimeException("error closing InputStreamReader for resource: " + resource, e);
 				}
 			}
 		}
+		return dataset;
 	}
 	
 	/* 

--- a/src/main/java/atoml/smoke/SmoketestFromArff.java
+++ b/src/main/java/atoml/smoke/SmoketestFromArff.java
@@ -10,11 +10,16 @@ import weka.core.Instances;
 public class SmoketestFromArff extends AbstractSmokeTest {
 
 	private final String resource;
-	
+	private final String additionalResource;
+
 	public SmoketestFromArff(String name, String resource) {
+		this(name, resource, null);
+	}
+	public SmoketestFromArff(String name, String resource, String additionalResource) {
 		super();
 		this.name = name;
 		this.resource = resource;
+		this.additionalResource = additionalResource;
 	}
 	
 	@Override
@@ -27,7 +32,18 @@ public class SmoketestFromArff extends AbstractSmokeTest {
         catch (IOException e) {
             throw new RuntimeException("error reading ARFF from resource: " + resource, e);
         }
-        testdata = data;
+        if (additionalResource == null){
+			testdata = data;
+		} else{
+			InputStreamReader additionalFile = new InputStreamReader(
+					this.getClass().getResourceAsStream(additionalResource));
+			try(BufferedReader reader = new BufferedReader(additionalFile);) {
+				testdata = new Instances(reader);
+			}
+			catch (IOException e) {
+				throw new RuntimeException("error reading ARFF from resource: " + additionalResource, e);
+			}
+		}
 	}
 	
 	/* 

--- a/src/main/java/atoml/smoke/SmoketestFromArff.java
+++ b/src/main/java/atoml/smoke/SmoketestFromArff.java
@@ -9,39 +9,77 @@ import weka.core.Instances;
 
 public class SmoketestFromArff extends AbstractSmokeTest {
 
-	private final String resource;
-	private final String additionalResource;
+	private final String trainingResource;
+	private final String testResource;
 
-	public SmoketestFromArff(String name, String resource) {
-		this(name, resource, null);
+	public SmoketestFromArff(String name, String trainingResource) {
+		this(name, trainingResource, trainingResource);
 	}
-	public SmoketestFromArff(String name, String resource, String additionalResource) {
+	public SmoketestFromArff(String name, String trainingResource, String testResource) {
 		super();
 		this.name = name;
-		this.resource = resource;
-		this.additionalResource = additionalResource;
+		this.trainingResource = trainingResource;
+		this.testResource = testResource;
+		if (this.trainingResource == null) {
+			throw new RuntimeException("error training data ARFF resource for smoke test generation is null");
+		}
+		if (this.testResource == null){
+			throw new RuntimeException("error test data ARFF resource for smoke test generation is null");
+		}
 	}
 	
 	@Override
 	public void generateData(int numFeatures, int numInstances, long seed) {
-        InputStreamReader originalFile = new InputStreamReader(
-                 this.getClass().getResourceAsStream(resource));
-        try(BufferedReader reader = new BufferedReader(originalFile);) {
-            data = new Instances(reader);
-        }
-        catch (IOException e) {
-            throw new RuntimeException("error reading ARFF from resource: " + resource, e);
-        }
-        if (additionalResource == null){
-			testdata = data;
-		} else{
-			InputStreamReader additionalFile = new InputStreamReader(
-					this.getClass().getResourceAsStream(additionalResource));
-			try(BufferedReader reader = new BufferedReader(additionalFile);) {
-				testdata = new Instances(reader);
+		InputStreamReader trainingFile = null;
+		BufferedReader trainingReader = null;
+		try{
+			trainingFile = new InputStreamReader(this.getClass().getResourceAsStream(trainingResource));
+			trainingReader = new BufferedReader(trainingFile);
+			data = new Instances(trainingReader);
+		}
+		catch (IOException e) {
+			throw new RuntimeException("error reading ARFF from resource: " + trainingResource, e);
+		}
+		finally {
+			if (trainingReader != null) {
+				try {
+					trainingReader.close();
+				} catch (IOException e) {
+					throw new RuntimeException("error closing BufferedReader for resource: " + trainingResource, e);
+				}
 			}
-			catch (IOException e) {
-				throw new RuntimeException("error reading ARFF from resource: " + additionalResource, e);
+			if (trainingFile != null){
+				try {
+					trainingFile.close();
+				} catch (IOException e) {
+					throw new RuntimeException("error closing InputStreamReader for resource: " + trainingResource, e);
+				}
+			}
+		}
+		InputStreamReader testFile = null;
+		BufferedReader testReader = null;
+		try{
+			testFile = new InputStreamReader(this.getClass().getResourceAsStream(testResource));
+			testReader = new BufferedReader(testFile);
+			testdata = new Instances(testReader);
+		}
+		catch (IOException e) {
+			throw new RuntimeException("error reading ARFF from resource: " + testResource, e);
+		}
+		finally {
+			if (testReader != null) {
+				try {
+					testReader.close();
+				} catch (IOException e) {
+					throw new RuntimeException("error closing BufferedReader for resource: " + testResource, e);
+				}
+			}
+			if (testFile != null){
+				try {
+					testFile.close();
+				} catch (IOException e) {
+					throw new RuntimeException("error closing InputStreamReader for resource: " + testResource, e);
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Enable the option to give an additional resource to 'SmoketestFromArff', which is used as the testdata.