### PR TITLE
additions for the differential testing

### DIFF
--- a/src/main/java/atoml/smoke/SmoketestFromArff.java
+++ b/src/main/java/atoml/smoke/SmoketestFromArff.java
@@ -17,23 +17,35 @@ public class SmoketestFromArff extends AbstractSmokeTest {
 
 	private final String trainingResource;
 	private final String testResource;
-
+	private final FeatureType featureType;
+	
 	/**
-	 * creates a new SmoketestFromArff, where training data == test data
+	 * creates a new SmoketestFromArff with feature type DOUBLE, where training data == test data
 	 * @param name identifier name of the test
 	 * @param trainingResource resource path of the ARFF file with the data
 	 */
 	public SmoketestFromArff(String name, String trainingResource) {
-		this(name, trainingResource, trainingResource);
+		this(name, trainingResource, trainingResource, FeatureType.DOUBLE);
 	}
 
 	/**
-	 * creates a new SmoketestFromArff
+	 * creates a new SmoketestFromArff with feature type DOUBLE
 	 * @param name identifier name of the test
 	 * @param trainingResource resource path of the ARFF file with the training data
 	 * @param testResource resource path of the ARFF file with the test data
 	 */
 	public SmoketestFromArff(String name, String trainingResource, String testResource) {
+		this(name, trainingResource, testResource, FeatureType.DOUBLE);
+	}
+
+	/**
+	 * creates a new SmoketestFromArff with a defined feature type
+	 * @param name identifier name of the test
+	 * @param trainingResource resource path of the ARFF file with the training data
+	 * @param testResource resource path of the ARFF file with the test data
+	 * @param featureType feature type of the dataset (e.g. double, positivedouble, categorial...)
+	 */
+	public SmoketestFromArff(String name, String trainingResource, String testResource, FeatureType featureType) {
 		super();
 		this.name = name;
 		this.trainingResource = trainingResource;
@@ -44,6 +56,7 @@ public class SmoketestFromArff extends AbstractSmokeTest {
 		if (this.testResource == null){
 			throw new RuntimeException("error test data ARFF resource for smoke test generation is null");
 		}
+		this.featureType = featureType;
 	}
 
 	/*
@@ -101,6 +114,6 @@ public class SmoketestFromArff extends AbstractSmokeTest {
 	 */
 	@Override
 	public FeatureType getFeatureType() {
-		return FeatureType.DOUBLE;
+		return this.featureType;
 	}
 }

--- a/src/main/java/atoml/testgen/CaretTemplate.java
+++ b/src/main/java/atoml/testgen/CaretTemplate.java
@@ -48,17 +48,11 @@ public class CaretTemplate implements TemplateEngine {
 	 */
 	@Override
 	public Map<String, String> getClassReplacements() {
-		boolean setRparamsFlag = true;
-		StringBuilder rparamsString = new StringBuilder();
 		StringBuilder parameterString = new StringBuilder();
 		parameterString.append("paramGrid <- c(\n");
 		if( algorithmUnderTest.getParameterCombinations().size()>0 ) {
 			for( Map<String,String> parameterCombination :  algorithmUnderTest.getParameterCombinations()) {
 				parameterString.append("              " + getParameterString(parameterCombination) + ",\n");
-				if ( setRparamsFlag ){
-					rparamsString.append(getRparamsString(parameterCombination));
-					setRparamsFlag = false;
-				}
 			}
 			parameterString.replace(parameterString.length()-2, parameterString.length(), "");
 		}
@@ -67,7 +61,6 @@ public class CaretTemplate implements TemplateEngine {
 		Map<String, String> replacements = new HashMap<>();
 		replacements.put("<<<PACKAGENAME>>>", algorithmUnderTest.getPackage());
 		replacements.put("<<<HYPERPARAMETERS>>>", parameterString.toString());
-		replacements.put("<<<RPARAMS>>>", rparamsString.toString());
 		return replacements;
 	}
 	
@@ -76,9 +69,17 @@ public class CaretTemplate implements TemplateEngine {
 	 */
 	@Override
 	public Map<String, String> getSmoketestReplacements(SmokeTest smokeTest) {
+		StringBuilder rparamsString = new StringBuilder();
+		if( algorithmUnderTest.getParameterCombinations().size()>0 ) {
+			for( Map<String,String> parameterCombination :  algorithmUnderTest.getParameterCombinations()) {
+				rparamsString.append(getRparamsString(parameterCombination));
+				break;
+			}
+		}
 		Map<String, String> replacements = new HashMap<>();
 		replacements.put("<<<PACKAGENAME>>>", algorithmUnderTest.getPackage());
 		replacements.put("<<<CLASSIFIER>>>", algorithmUnderTest.getClassName());
+		replacements.put("<<<RPARAMS>>>", rparamsString.toString());
 		return replacements;
 	}
 

--- a/src/main/resources/caret-classification-class.template
+++ b/src/main/resources/caret-classification-class.template
@@ -4,9 +4,9 @@ library(patrick)
 library(R.utils)
 library(testthat)
 
-if(!require("<<<PACKAGENAME>>>", character.only = TRUE )){
+if(!require("<<<PACKAGENAME>>>", character.only = TRUE ))
   install.packages("<<<PACKAGENAME>>>", dependencies = TRUE)
-  library("<<<PACKAGENAME>>>", character.only = TRUE)}
+library("<<<PACKAGENAME>>>", character.only = TRUE)
 
 <<<HYPERPARAMETERS>>>
 

--- a/src/main/resources/caret-classification-smoketest-csv.template
+++ b/src/main/resources/caret-classification-smoketest-csv.template
@@ -20,9 +20,19 @@ withTimeout(timeout=<<<TIMEOUT>>>, onTimeout="error", expr={
                            y = train_y,
                            method = "<<<CLASSIFIER>>>",
                            tuneGrid = paramSet,
-                           trControl = control)
+                           trControl = control
+                           <<<RPARAMS>>>)
             predictions <- predict(model, test_x)
-            probabilities <- predict(model, test_x, type = "prob")
+            probabilities <- array(-1,dim = c(length(test_y),2))
+            tryCatch(
+                expr = {
+                    probabilities <- predict(model, test_x, type = "prob")
+                },
+                error = function(e){
+                    message('An error occured during the prediction of the probabilities! Values left at default (-1).')
+                    print(e)
+                }
+            )
             actual_classes <- as.integer(test_y) - 1
             pred_classes <- as.integer(predictions) - 1
             csv_df <- cbind(actual = actual_classes,
@@ -34,9 +44,19 @@ withTimeout(timeout=<<<TIMEOUT>>>, onTimeout="error", expr={
                     file = csv_file,
                     row.names = FALSE)
             print(paste0("Predictions saved at: ", csv_file))
+
             # training data as test data
             predictions_training_as_test <- predict(model, train_x)
-            probabilities_training_as_test <- predict(model, train_x, type = "prob")
+            probabilities_training_as_test <- array(-1,dim = c(length(train_y),2))
+            tryCatch(
+                expr = {
+                    probabilities_training_as_test <- predict(model, train_x, type = "prob")
+                },
+                error = function(e){
+                    message('An error occured during the prediction of the probabilities! Values left at default (-1).')
+                    print(e)
+                }
+            )
             actual_classes_training_as_test <- as.integer(train_y) - 1
             pred_classes_training_as_test <- as.integer(predictions_training_as_test) - 1
             csv_df <- cbind(actual = actual_classes_training_as_test,

--- a/src/main/resources/caret-classification-smoketest-csv.template
+++ b/src/main/resources/caret-classification-smoketest-csv.template
@@ -26,6 +26,9 @@ withTimeout(timeout=<<<TIMEOUT>>>, onTimeout="error", expr={
             probabilities <- array(-1,dim = c(length(test_y),2))
             tryCatch(
                 expr = {
+                    if (any(is.na(predict(model, test_x, type = "prob")))){
+                        stop("At least one of the predicted probability values is NaN.")
+                    }
                     probabilities <- predict(model, test_x, type = "prob")
                 },
                 error = function(e){
@@ -49,6 +52,9 @@ withTimeout(timeout=<<<TIMEOUT>>>, onTimeout="error", expr={
             probabilities_training_as_test <- array(-1,dim = c(length(train_y),2))
             tryCatch(
                 expr = {
+                    if (any(is.na(predict(model, train_x, type = "prob")))){
+                        stop("At least one of the predicted probability values is NaN.")
+                    }
                     probabilities_training_as_test <- predict(model, train_x, type = "prob")
                 },
                 error = function(e){

--- a/src/main/resources/caret-classification-smoketest-csv.template
+++ b/src/main/resources/caret-classification-smoketest-csv.template
@@ -16,7 +16,7 @@ withTimeout(timeout=<<<TIMEOUT>>>, onTimeout="error", expr={
             colnames(paramSet) <- paramNames
 
             control <- trainControl(method = "none")
-            model <- train(x = train_x,
+            model <- caret::train(x = train_x,
                            y = train_y,
                            method = "<<<CLASSIFIER>>>",
                            tuneGrid = paramSet,

--- a/src/main/resources/caret-classification-smoketest-csv.template
+++ b/src/main/resources/caret-classification-smoketest-csv.template
@@ -32,7 +32,7 @@ withTimeout(timeout=<<<TIMEOUT>>>, onTimeout="error", expr={
                     probabilities <- predict(model, test_x, type = "prob")
                 },
                 error = function(e){
-                    message('The prediction of the probabilities failed. Values set to default (-1).')
+                    message("The prediction of the probabilities failed. Values set to default (-1).")
                 }
             )
             actual_classes <- as.integer(test_y) - 1
@@ -58,7 +58,7 @@ withTimeout(timeout=<<<TIMEOUT>>>, onTimeout="error", expr={
                     probabilities_training_as_test <- predict(model, train_x, type = "prob")
                 },
                 error = function(e){
-                    message('The prediction of the probabilities failed. Values set to default (-1).')
+                    message("The prediction of the probabilities failed. Values set to default (-1).")
                 }
             )
             actual_classes_training_as_test <- as.integer(train_y) - 1

--- a/src/main/resources/caret-classification-smoketest-csv.template
+++ b/src/main/resources/caret-classification-smoketest-csv.template
@@ -29,8 +29,7 @@ withTimeout(timeout=<<<TIMEOUT>>>, onTimeout="error", expr={
                     probabilities <- predict(model, test_x, type = "prob")
                 },
                 error = function(e){
-                    message('An error occured during the prediction of the probabilities! Values left at default (-1).')
-                    print(e)
+                    message('The prediction of the probabilities failed. Values set to default (-1).')
                 }
             )
             actual_classes <- as.integer(test_y) - 1
@@ -53,8 +52,7 @@ withTimeout(timeout=<<<TIMEOUT>>>, onTimeout="error", expr={
                     probabilities_training_as_test <- predict(model, train_x, type = "prob")
                 },
                 error = function(e){
-                    message('An error occured during the prediction of the probabilities! Values left at default (-1).')
-                    print(e)
+                    message('The prediction of the probabilities failed. Values set to default (-1).')
                 }
             )
             actual_classes_training_as_test <- as.integer(train_y) - 1

--- a/src/main/resources/caret-classification-smoketest.template
+++ b/src/main/resources/caret-classification-smoketest.template
@@ -20,7 +20,8 @@ withTimeout(timeout=<<<TIMEOUT>>>, onTimeout="error", expr={
                            y = train_y,
                            method = "<<<CLASSIFIER>>>",
                            tuneGrid = paramSet,
-                           trControl = control)
+                           trControl = control
+                           <<<RPARAMS>>>)
             predictions <- predict(model, test_x)
         }
     expect_true(TRUE)

--- a/src/main/resources/caret-classification-smoketest.template
+++ b/src/main/resources/caret-classification-smoketest.template
@@ -16,7 +16,7 @@ withTimeout(timeout=<<<TIMEOUT>>>, onTimeout="error", expr={
             colnames(paramSet) <- paramNames
 
             control <- trainControl(method = "none")
-            model <- train(x = train_x,
+            model <- caret::train(x = train_x,
                            y = train_y,
                            method = "<<<CLASSIFIER>>>",
                            tuneGrid = paramSet,

--- a/src/main/resources/sklearn-classification-smoketest-csv.template
+++ b/src/main/resources/sklearn-classification-smoketest-csv.template
@@ -26,7 +26,7 @@
             try:
                 pred_prob = np.array(classifier.predict_proba(np.delete(testdata_df.values, classIndex, axis=1)))
             except AttributeError as e:
-                print('An error occured during the prediction of the probabilities, values left at default (-1):', e)
+                print('The prediction of the probabilities failed. Values set to default (-1).')
             try:
                 main_dir = Path(__file__).resolve().parents[2]
                 prediction_file = os.path.join(main_dir, "predictions", "pred_<<<IDENTIFIER>>>_<<<NAME>>>_" + str(iter) + ".csv")
@@ -45,7 +45,7 @@
             try:
                 pred_prob_training_as_test = np.array(classifier.predict_proba(np.delete(data_df.values, classIndex, axis=1)))
             except Exception as e:
-                print('An error occured during the prediction of the probabilities, values left at default (-1):', e)
+                print('The prediction of the probabilities failed. Values set to default (-1).')
             try:
               main_dir = Path(__file__).resolve().parents[2]
               prediction_file_training_as_test = os.path.join(main_dir, "predictions", "pred_<<<IDENTIFIER>>>_<<<NAME>>>_TrainingAsTest_" + str(iter) + ".csv")

--- a/src/main/resources/sklearn-classification-smoketest-csv.template
+++ b/src/main/resources/sklearn-classification-smoketest-csv.template
@@ -22,8 +22,12 @@
             <<<MYSQLINDENT>>>np.random.seed(42)
             <<<MYSQLINDENT>>>classifier.fit(np.delete(data_df.values, classIndex, axis=1),data_df.values[:,classIndex])
             <<<MYSQLINDENT>>>predicted_label = classifier.predict(np.delete(testdata_df.values, classIndex, axis=1))<<<MYSQLEVALSMOKE_END>>>
+            pred_prob = np.full((testdata_df.shape[0],2), -1)
             try:
                 pred_prob = np.array(classifier.predict_proba(np.delete(testdata_df.values, classIndex, axis=1)))
+            except AttributeError as e:
+                print('An error occured during the prediction of the probabilities, values left at default (-1):', e)
+            try:
                 main_dir = Path(__file__).resolve().parents[2]
                 prediction_file = os.path.join(main_dir, "predictions", "pred_<<<IDENTIFIER>>>_<<<NAME>>>_" + str(iter) + ".csv")
                 pred_df = pd.DataFrame()
@@ -35,9 +39,14 @@
                 print("Predictions saved at: " + prediction_file)
             except Exception as e:
                 print("Saving the predictions of <<<NAME>>> for <<<IDENTIFIER>>> failed: ", e)
+
+            predicted_label_training_as_test = classifier.predict(np.delete(data_df.values, classIndex, axis=1))
+            pred_prob_training_as_test = np.full((data_df.shape[0],2), -1)
             try:
-              predicted_label_training_as_test = classifier.predict(np.delete(data_df.values, classIndex, axis=1))
-              pred_prob_training_as_test = np.array(classifier.predict_proba(np.delete(data_df.values, classIndex, axis=1)))
+                pred_prob_training_as_test = np.array(classifier.predict_proba(np.delete(data_df.values, classIndex, axis=1)))
+            except Exception as e:
+                print('An error occured during the prediction of the probabilities, values left at default (-1):', e)
+            try:
               main_dir = Path(__file__).resolve().parents[2]
               prediction_file_training_as_test = os.path.join(main_dir, "predictions", "pred_<<<IDENTIFIER>>>_<<<NAME>>>_TrainingAsTest_" + str(iter) + ".csv")
               pred_df = pd.DataFrame()

--- a/src/main/resources/sklearn-classification-smoketest-csv.template
+++ b/src/main/resources/sklearn-classification-smoketest-csv.template
@@ -26,7 +26,7 @@
             try:
                 pred_prob = np.array(classifier.predict_proba(np.delete(testdata_df.values, classIndex, axis=1)))
             except AttributeError as e:
-                print('The prediction of the probabilities failed. Values set to default (-1).')
+                print("The prediction of the probabilities failed. Values set to default (-1).")
             try:
                 main_dir = Path(__file__).resolve().parents[2]
                 prediction_file = os.path.join(main_dir, "predictions", "pred_<<<IDENTIFIER>>>_<<<NAME>>>_" + str(iter) + ".csv")
@@ -45,7 +45,7 @@
             try:
                 pred_prob_training_as_test = np.array(classifier.predict_proba(np.delete(data_df.values, classIndex, axis=1)))
             except Exception as e:
-                print('The prediction of the probabilities failed. Values set to default (-1).')
+                print("The prediction of the probabilities failed. Values set to default (-1).")
             try:
               main_dir = Path(__file__).resolve().parents[2]
               prediction_file_training_as_test = os.path.join(main_dir, "predictions", "pred_<<<IDENTIFIER>>>_<<<NAME>>>_TrainingAsTest_" + str(iter) + ".csv")

--- a/src/main/resources/spark-classification-class.template
+++ b/src/main/resources/spark-classification-class.template
@@ -35,6 +35,7 @@ import smile.stat.hypothesis.KSTest;
 import smile.stat.hypothesis.ChiSqTest;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Encoders;
+import org.apache.spark.sql.functions;
 import org.apache.spark.sql.Row;
 import org.apache.spark.sql.RowFactory;
 import org.apache.spark.sql.SparkSession;

--- a/src/main/resources/spark-classification-smoketest-csv.template
+++ b/src/main/resources/spark-classification-smoketest-csv.template
@@ -16,6 +16,14 @@
 
             ClassificationModel<?, ?> model = classifier.fit(dataframe);
             Dataset<Row> pred = model.transform(testdata);<<<MYSQLEVALSMOKE_END>>>
+            Dataset<Row> predSelect = pred.select("classAtt", "prediction");
+            try {
+                predSelect = pred.select("classAtt", "prediction", "probability");
+            } catch (Exception e) {
+                predSelect = predSelect.withColumn("prob_0", functions.lit(-1));
+                predSelect = predSelect.withColumn("prob_1", functions.lit(-1));
+                System.out.print("Not able to access probabilities, values are set to default (-1).");
+            }
             // create a csv file
             String filePath = "predictions/pred_<<<IDENTIFIER>>>_<<<NAME>>>_" + iter + ".csv";
             try {
@@ -31,7 +39,6 @@
                 // write header
                 outWriter.write("actual,prediction,prob_0,prob_1\\n");
                 // write predictions
-                Dataset<Row> predSelect = pred.select("classAtt", "prediction", "probability");
                 List<String> predString = predSelect.map((MapFunction<Row, String>) row -> row.mkString(","), Encoders.STRING()).collectAsList();
                 for (String s : predString) {
                     outWriter.write(s.replace("[", "").replace("]", "") + '\\n');
@@ -42,8 +49,17 @@
                 System.out.println( "Writing the predictions to csv file failed." );
                 e.printStackTrace();
             }
+
             // training data as test data
             Dataset<Row> predTrainingAsTest = model.transform(dataframe);
+            Dataset<Row> predSelectTrainingAsTest = predTrainingAsTest.select("classAtt", "prediction");
+            try {
+                predSelectTrainingAsTest = predTrainingAsTest.select("classAtt", "prediction", "probability");
+            } catch (Exception e) {
+                predSelectTrainingAsTest = predSelectTrainingAsTest.withColumn("prob_0", functions.lit(-1));
+                predSelectTrainingAsTest = predSelectTrainingAsTest.withColumn("prob_1", functions.lit(-1));
+                System.out.print("Not able to access probabilities, values are set to default (-1).");
+            }
             // create a csv file
             String filePathTrainingAsTest = "predictions/pred_<<<IDENTIFIER>>>_<<<NAME>>>_TrainingAsTest_" + iter + ".csv";
             try {
@@ -59,7 +75,6 @@
                 // write header
                 outWriterTrainingAsTest.write("actual,prediction,prob_0,prob_1\\n");
                 // write predictions
-                Dataset<Row> predSelectTrainingAsTest = predTrainingAsTest.select("classAtt", "prediction", "probability");
                 List<String> predStringTrainingAsTest = predSelectTrainingAsTest.map((MapFunction<Row, String>) row -> row.mkString(","), Encoders.STRING()).collectAsList();
                 for (String s : predStringTrainingAsTest) {
                     outWriterTrainingAsTest.write(s.replace("[", "").replace("]", "") + '\\n');

--- a/src/main/resources/spark-classification-smoketest-csv.template
+++ b/src/main/resources/spark-classification-smoketest-csv.template
@@ -22,7 +22,7 @@
             } catch (Exception e) {
                 predSelect = predSelect.withColumn("prob_0", functions.lit(-1));
                 predSelect = predSelect.withColumn("prob_1", functions.lit(-1));
-                System.out.print('The prediction of the probabilities failed. Values set to default (-1).');
+                System.out.print("The prediction of the probabilities failed. Values set to default (-1).");
             }
             // create a csv file
             String filePath = "predictions/pred_<<<IDENTIFIER>>>_<<<NAME>>>_" + iter + ".csv";
@@ -58,7 +58,7 @@
             } catch (Exception e) {
                 predSelectTrainingAsTest = predSelectTrainingAsTest.withColumn("prob_0", functions.lit(-1));
                 predSelectTrainingAsTest = predSelectTrainingAsTest.withColumn("prob_1", functions.lit(-1));
-                System.out.print('The prediction of the probabilities failed. Values set to default (-1).');
+                System.out.print("The prediction of the probabilities failed. Values set to default (-1).");
             }
             // create a csv file
             String filePathTrainingAsTest = "predictions/pred_<<<IDENTIFIER>>>_<<<NAME>>>_TrainingAsTest_" + iter + ".csv";

--- a/src/main/resources/spark-classification-smoketest-csv.template
+++ b/src/main/resources/spark-classification-smoketest-csv.template
@@ -22,7 +22,7 @@
             } catch (Exception e) {
                 predSelect = predSelect.withColumn("prob_0", functions.lit(-1));
                 predSelect = predSelect.withColumn("prob_1", functions.lit(-1));
-                System.out.print("Not able to access probabilities, values are set to default (-1).");
+                System.out.print('The prediction of the probabilities failed. Values set to default (-1).');
             }
             // create a csv file
             String filePath = "predictions/pred_<<<IDENTIFIER>>>_<<<NAME>>>_" + iter + ".csv";
@@ -58,7 +58,7 @@
             } catch (Exception e) {
                 predSelectTrainingAsTest = predSelectTrainingAsTest.withColumn("prob_0", functions.lit(-1));
                 predSelectTrainingAsTest = predSelectTrainingAsTest.withColumn("prob_1", functions.lit(-1));
-                System.out.print("Not able to access probabilities, values are set to default (-1).");
+                System.out.print('The prediction of the probabilities failed. Values set to default (-1).');
             }
             // create a csv file
             String filePathTrainingAsTest = "predictions/pred_<<<IDENTIFIER>>>_<<<NAME>>>_TrainingAsTest_" + iter + ".csv";

--- a/testdata/caret_descriptions.yml
+++ b/testdata/caret_descriptions.yml
@@ -59,6 +59,9 @@
 #  - flag       flag that is either enabled or disabled; both will be tested with the default values of the other parameters
 #  - fixedflag  a flag that is always used with the default value - probably only makes sense with the value enabled.
 #  - values     list of values that will be tested with the default values of the other parameters
+# Caret specific property: A parameter can carry the 'rparam.' prefix, e.g., 'rparam.num.trees'. This prefix signals
+#               that the parameter is not a hyperparameter available in caret, but a parameter only available as
+#               a keyword argument from the underlying package. These parameters do only support a default value.
 
 #####################
 # Caret Classifiers #


### PR DESCRIPTION
- mainly changes in the templates to handle missing probability predictions of algorithms
- add 'rparam.' parameter for caret, in order to hand over parameters to underlying packages
- add possibility to have a SmoketestFromArff with a feature type other than double